### PR TITLE
chore: fix reviewed interface and TypeScript codegen regressions

### DIFF
--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -108,32 +108,27 @@ func (funcs typescriptTemplateFuncs) isInterface(t *introspection.Type) bool {
 	return t.Kind == introspection.TypeKindInterface
 }
 
-// formatInputType returns a function that formats input values. Arguments
-// named id stay on the ID scalar surface in modern mode, and become typed
-// legacy FooID aliases in legacy mode when @expectedType identifies a concrete
-// object/interface.
+// formatInputType returns a function that formats input values.
 func (funcs typescriptTemplateFuncs) formatInputType(
 	commonFunc *generator.CommonFunctions,
 ) func(arg introspection.InputValue, scopes ...string) (string, error) {
 	return func(arg introspection.InputValue, scopes ...string) (string, error) {
-		if arg.Name == "id" {
-			if funcs.legacyTypeScriptSDKCompat() {
-				if expectedType := arg.Directives.ExpectedType(); expectedType != "" && expectedType != "Node" && !strings.HasPrefix(expectedType, "_") {
-					representation := funcs.scoped(scopes...) + funcs.legacyIDName(expectedType)
-					if arg.TypeRef != nil && arg.TypeRef.IsList() {
-						representation += "[]"
-					}
-					return representation, nil
-				}
-			}
-			return commonFunc.FormatOutputType(arg.TypeRef, scopes...)
-		}
 		if expectedType := arg.Directives.ExpectedType(); expectedType != "" {
+			if arg.Name == "id" && funcs.legacyTypeScriptSDKCompat() && expectedType != "Node" && !strings.HasPrefix(expectedType, "_") {
+				representation := funcs.scoped(scopes...) + funcs.legacyIDName(expectedType)
+				if arg.TypeRef != nil && arg.TypeRef.IsList() {
+					representation += "[]"
+				}
+				return representation, nil
+			}
 			representation := funcs.scoped(scopes...) + funcs.formatName(expectedType)
 			if arg.TypeRef != nil && arg.TypeRef.IsList() {
 				representation += "[]"
 			}
 			return representation, nil
+		}
+		if arg.Name == "id" {
+			return commonFunc.FormatOutputType(arg.TypeRef, scopes...)
 		}
 		return commonFunc.FormatInputType(arg.TypeRef, scopes...)
 	}

--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -68,6 +68,7 @@ func (funcs typescriptTemplateFuncs) FuncMap() template.FuncMap {
 		"ConvertID":                 commonFunc.ConvertID,
 		"IsSelfChainable":           commonFunc.IsSelfChainable,
 		"IsListOfObject":            commonFunc.IsListOfObject,
+		"IsListOfInterface":         funcs.isListOfInterface,
 		"IsListOfEnum":              commonFunc.IsListOfEnum,
 		"GetArrayField":             commonFunc.GetArrayField,
 		"ToLowerCase":               commonFunc.ToLowerCase,
@@ -132,6 +133,21 @@ func (funcs typescriptTemplateFuncs) formatInputType(
 		}
 		return commonFunc.FormatInputType(arg.TypeRef, scopes...)
 	}
+}
+
+func (funcs typescriptTemplateFuncs) isListOfInterface(t *introspection.TypeRef) bool {
+	if t == nil || !t.IsList() {
+		return false
+	}
+	for ref := t; ref != nil; ref = ref.OfType {
+		switch ref.Kind {
+		case introspection.TypeKindNonNull, introspection.TypeKindList:
+			continue
+		default:
+			return ref.Kind == introspection.TypeKindInterface
+		}
+	}
+	return false
 }
 
 // formatFieldOutputType returns the raw response value type for a field. Legacy

--- a/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
@@ -98,7 +98,11 @@
       {{- end }}
     {{- else if not .TypeRef.IsVoid -}}
         {{- if and .TypeRef.IsList (IsListOfObject .TypeRef) }}
+          {{- if IsListOfInterface .TypeRef }}
+    return response.map((r) => new _{{ . | FormatReturnType | ToSingleType | FormatProtected | FormatName }}Client(ctx.copy().selectNode(r.id, "{{ . | FormatReturnType | ToSingleType | FormatProtected }}")))
+          {{- else }}
     return response.map((r) => new {{ . | FormatReturnType | ToSingleType | FormatProtected | FormatName }}(ctx.copy().selectNode(r.id, "{{ . | FormatReturnType | ToSingleType | FormatProtected }}")))
+          {{- end }}
         {{- else if and .TypeRef.IsList (IsListOfEnum .TypeRef) -}}
     return response.map((r) => {{ . | FormatReturnType | ToSingleType }}NameToValue(r))
         {{- else if .TypeRef.IsEnum }}

--- a/cmd/codegen/generator/typescript/templates/src/object_test.go
+++ b/cmd/codegen/generator/typescript/templates/src/object_test.go
@@ -335,6 +335,17 @@ func TestModernTypeScriptIDSurface(t *testing.T) {
 	require.Contains(t, got, "const response: Awaited<ID> = await ctx.execute()")
 }
 
+func TestModernTypeScriptFileInputNamedIDUsesFileType(t *testing.T) {
+	schema := objectsInit(t, legacyUnifiedIDSchemaJSON)
+	generator.SetSchema(&schema)
+	t.Cleanup(func() { generator.SetSchema(nil) })
+
+	got := renderAPI(t, &schema, "v0.21.0-dev")
+
+	require.Contains(t, got, "file = (id: File): File => {")
+	require.NotContains(t, got, "file = (id: ID): File => {")
+}
+
 func renderAPI(t *testing.T, schema *introspection.Schema, schemaVersion string) string {
 	t.Helper()
 	tmpl := templates.New(schemaVersion, generator.Config{})

--- a/cmd/codegen/generator/typescript/templates/src/object_test.go
+++ b/cmd/codegen/generator/typescript/templates/src/object_test.go
@@ -417,6 +417,79 @@ func TestInterfaceConvertIDMethodConstructsClient(t *testing.T) {
 	require.NotContains(t, got, `return new Syncer(`)
 }
 
+func TestInterfaceListReturnUsesClientWrapper(t *testing.T) {
+	var schemaJSON = `
+[
+  {
+    "kind": "SCALAR",
+    "name": "ID",
+    "description": "",
+    "fields": null,
+    "inputFields": null,
+    "interfaces": [],
+    "enumValues": null,
+    "possibleTypes": null
+  },
+  {
+    "kind": "INTERFACE",
+    "name": "Syncer",
+    "description": "",
+    "fields": [
+      {
+        "name": "id",
+        "description": "",
+        "args": [],
+        "type": { "kind": "NON_NULL", "ofType": { "kind": "SCALAR", "name": "ID" } },
+        "isDeprecated": false,
+        "deprecationReason": null
+      }
+    ],
+    "inputFields": null,
+    "interfaces": [],
+    "enumValues": null,
+    "possibleTypes": null
+  },
+  {
+    "kind": "OBJECT",
+    "name": "Query",
+    "description": "",
+    "fields": [
+      {
+        "name": "syncers",
+        "description": "",
+        "args": [],
+        "type": {
+          "kind": "NON_NULL",
+          "ofType": {
+            "kind": "LIST",
+            "ofType": {
+              "kind": "NON_NULL",
+              "ofType": { "kind": "INTERFACE", "name": "Syncer" }
+            }
+          }
+        },
+        "isDeprecated": false,
+        "deprecationReason": null
+      }
+    ],
+    "inputFields": null,
+    "interfaces": [],
+    "enumValues": null,
+    "possibleTypes": null
+  }
+]
+`
+	schema := objectsInit(t, schemaJSON)
+	generator.SetSchema(&schema)
+	t.Cleanup(func() { generator.SetSchema(nil) })
+
+	got := renderAPI(t, &schema, "v0.21.0-dev")
+
+	require.Contains(t, got, "syncers = async (): Promise<Syncer[]> => {")
+	require.Contains(t, got, `return response.map((r) => new _SyncerClient(ctx.copy().selectNode(r.id, "Syncer")))`)
+	require.NotContains(t, got, `new Syncer(`)
+}
+
 func objectInit(t *testing.T, jsonString string) *introspection.Type {
 	t.Helper()
 	var object introspection.Type

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -531,7 +531,7 @@ func (node *ModTreeNode) buildScaleOutModuleQuery(query *querybuilder.Selection)
 		if err != nil {
 			return nil, fmt.Errorf("encode dir ID: %w", err)
 		}
-		query = query.Select("node").Arg("id", dirIDEnc)
+		query = query.Select("node").Arg("id", dirIDEnc).InlineFragment("Directory")
 		query = query.Select("asModuleSource").
 			Arg("sourceRootPath", modSrc.DirSrc.OriginalSourceRootSubpath)
 	}

--- a/core/modtree_test.go
+++ b/core/modtree_test.go
@@ -4,17 +4,92 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/querybuilder"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+	"github.com/vektah/gqlparser/v2/validator"
 )
 
 type ModTreePathTestSuite struct {
 	suite.Suite
 }
 
+type ModTreeNodeTestSuite struct {
+	suite.Suite
+}
+
 func TestModTreePath(t *testing.T) {
 	testctx.New(t).RunTests(ModTreePathTestSuite{})
+}
+
+func TestModTreeNode(t *testing.T) {
+	testctx.New(t).RunTests(ModTreeNodeTestSuite{})
+}
+
+func (s *ModTreeNodeTestSuite) TestBuildScaleOutModuleQueryForModuleLoadedFromDirectory(ctx context.Context, t *testctx.T) {
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	require.NoError(t, err)
+	ctx = dagql.ContextWithCache(ctx, cache)
+
+	dag := newCoreDagqlServerForTest(t, &Query{})
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*Directory]{Typed: &Directory{}}))
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*ModuleSource]{Typed: &ModuleSource{}}))
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*Module]{Typed: &Module{}}))
+
+	sourceDir := newTypeDefAttachedResult(t, ctx, cache, dag, "sourceDir", &Directory{})
+	source := newTypeDefAttachedResult(t, ctx, cache, dag, "moduleSourceFromDirectory", &ModuleSource{
+		Kind: ModuleSourceKindDir,
+		DirSrc: &DirModuleSource{
+			OriginalContextDir:        sourceDir,
+			OriginalSourceRootSubpath: "src",
+		},
+	})
+	mod := newTypeDefAttachedResult(t, ctx, cache, dag, "module", &Module{
+		Source: dagql.NonNull(source),
+	})
+
+	query, err := (&ModTreeNode{Module: mod}).buildScaleOutModuleQuery(querybuilder.Query())
+	require.NoError(t, err)
+
+	generated, err := query.Select("id").Build(ctx)
+	require.NoError(t, err)
+
+	schema, err := gqlparser.LoadSchema(&ast.Source{Input: `
+		schema {
+			query: Query
+		}
+
+		interface Node {
+			id: ID!
+		}
+
+		type Query {
+			node(id: ID!): Node
+		}
+
+		type Directory implements Node {
+			id: ID!
+			asModuleSource(sourceRootPath: String!): ModuleSource!
+		}
+
+		type ModuleSource {
+			asModule: Module!
+		}
+
+		type Module {
+			id: ID!
+		}
+	`})
+	require.NoError(t, err)
+
+	doc, err := parser.ParseQuery(&ast.Source{Input: generated})
+	require.NoError(t, err)
+	require.Empty(t, validator.Validate(schema, doc), "generated query should validate:\n%s", generated)
 }
 
 func (s *ModTreePathTestSuite) TestIsParentOf(ctx context.Context, t *testctx.T) {

--- a/core/typedef_test_helpers_test.go
+++ b/core/typedef_test_helpers_test.go
@@ -180,7 +180,7 @@ func newTypeDefDetachedResult[T dagql.Typed](t *testing.T, dag *dagql.Server, op
 	return res
 }
 
-func newTypeDefAttachedResult[T dagql.Typed](t *testing.T, ctx context.Context, cache *dagql.Cache, dag *dagql.Server, op string, self T) dagql.ObjectResult[T] {
+func newTypeDefAttachedResult[T dagql.Typed](t testing.TB, ctx context.Context, cache *dagql.Cache, dag *dagql.Server, op string, self T) dagql.ObjectResult[T] {
 	t.Helper()
 	call := moduleObjectTestSyntheticCall(op, self)
 	detached, err := dagql.NewObjectResultForCall(self, dag, call)

--- a/dagql/dagql_test.go
+++ b/dagql/dagql_test.go
@@ -3582,7 +3582,7 @@ func TestInterfaces(t *testing.T) {
 		assert.Assert(t, foundSpatial, "Point should declare Spatial interface")
 	})
 
-	t.Run("Satisfies checks", func(t *testing.T) {
+	t.Run("object must have every field required by the interface", func(t *testing.T) {
 		srv := newExternalDagqlServerForTest(t, Query{})
 		points.Install[Query](srv)
 
@@ -3612,7 +3612,7 @@ func TestInterfaces(t *testing.T) {
 		}(), "Implements should panic for unsatisfied interface")
 	})
 
-	t.Run("Satisfies checks argument compatibility", func(t *testing.T) {
+	t.Run("object method args must match the interface method", func(t *testing.T) {
 		srv := newExternalDagqlServerForTest(t, Query{})
 		points.Install[Query](srv)
 
@@ -3680,7 +3680,30 @@ func TestInterfaces(t *testing.T) {
 		assert.Assert(t, !wrongArgType.Satisfies(pointType, ""), "Point should NOT satisfy WrongArgType")
 	})
 
-	t.Run("SatisfiedByInterface checks argument compatibility", func(t *testing.T) {
+	t.Run("object method cannot require an arg missing from the interface", func(t *testing.T) {
+		srv := newExternalDagqlServerForTest(t, Query{})
+
+		dagql.Fields[Query]{
+			dagql.Func("run", func(ctx context.Context, self Query, args struct {
+				Target string
+			}) (string, error) {
+				return "ok", nil
+			}),
+		}.Install(srv)
+
+		runnable := dagql.NewInterface("Runnable", "Can run.")
+		runnable.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "run",
+				Type: dagql.String(""),
+			},
+		})
+		srv.InstallInterface(runnable)
+
+		assert.Assert(t, !runnable.Satisfies(srv.Root().ObjectType(), ""), "run(target:) cannot be used where run() is required")
+	})
+
+	t.Run("interface method args must match the interface it claims to support", func(t *testing.T) {
 		srv := newExternalDagqlServerForTest(t, Query{})
 
 		// Interface A: transform(x: Int!, y: Int!): String!
@@ -3715,7 +3738,7 @@ func TestInterfaces(t *testing.T) {
 		assert.Assert(t, ifaceA.SatisfiedByInterface(ifaceB, ""), "B should satisfy A")
 		assert.Assert(t, ifaceB.SatisfiedByInterface(ifaceA, ""), "A should satisfy B")
 
-		// Interface C: transform(x: Int!, y: Int!, z: Int!): String! — extra arg
+		// Interface C: transform(x: Int!, y: Int!, z: Int!): String! — extra required arg
 		ifaceC := dagql.NewInterface("TransformC", "Transform interface C with extra arg.")
 		ifaceC.AddField(dagql.InterfaceFieldSpec{
 			FieldSpec: dagql.FieldSpec{
@@ -3730,10 +3753,26 @@ func TestInterfaces(t *testing.T) {
 		})
 		srv.InstallInterface(ifaceC)
 
-		// C satisfies A (has all of A's args plus more)
-		assert.Assert(t, ifaceA.SatisfiedByInterface(ifaceC, ""), "C should satisfy A (superset of args)")
+		// C cannot stand in for A because z is required and callers through A cannot provide it.
+		assert.Assert(t, !ifaceA.SatisfiedByInterface(ifaceC, ""), "TransformC cannot be used where TransformA is expected")
 		// A does NOT satisfy C (missing z arg)
 		assert.Assert(t, !ifaceC.SatisfiedByInterface(ifaceA, ""), "A should NOT satisfy C (missing arg)")
+
+		// Interface CDefault: extra arg with a default is allowed.
+		ifaceCDefault := dagql.NewInterface("TransformCDefault", "Transform interface C with defaulted extra arg.")
+		ifaceCDefault.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "transform",
+				Type: dagql.String(""),
+				Args: dagql.NewInputSpecs(
+					dagql.InputSpec{Name: "x", Type: dagql.Int(0)},
+					dagql.InputSpec{Name: "y", Type: dagql.Int(0)},
+					dagql.InputSpec{Name: "z", Type: dagql.Int(0), Default: dagql.Int(0)},
+				),
+			},
+		})
+		srv.InstallInterface(ifaceCDefault)
+		assert.Assert(t, ifaceA.SatisfiedByInterface(ifaceCDefault, ""), "TransformCDefault can be used where TransformA is expected")
 
 		// Interface D: transform(x: String!): String! — different arg type
 		ifaceD := dagql.NewInterface("TransformD", "Transform interface D with wrong arg type.")

--- a/dagql/dagql_test.go
+++ b/dagql/dagql_test.go
@@ -3791,6 +3791,80 @@ func TestInterfaces(t *testing.T) {
 		assert.Assert(t, !ifaceA.SatisfiedByInterface(ifaceD, ""), "D should NOT satisfy A (arg type mismatch)")
 	})
 
+	t.Run("nullable list result cannot replace non-null list result", func(t *testing.T) {
+		srv := newExternalDagqlServerForTest(t, Query{})
+		dagql.Fields[Query]{
+			dagql.Func("namesOrNull", func(ctx context.Context, self Query, args struct{}) (dagql.Nullable[dagql.Array[dagql.String]], error) {
+				return dagql.Null[dagql.Array[dagql.String]](), nil
+			}),
+			dagql.Func("names", func(ctx context.Context, self Query, args struct{}) (dagql.Array[dagql.String], error) {
+				return dagql.NewStringArray("a"), nil
+			}),
+		}.Install(srv)
+
+		nonNullListIface := dagql.NewInterface("NonNullList", "Requires a non-null list.")
+		nonNullListIface.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "namesOrNull",
+				Type: dagql.Array[dagql.String]{},
+			},
+		})
+		srv.InstallInterface(nonNullListIface)
+		assert.Assert(t, !nonNullListIface.Satisfies(srv.Root().ObjectType(), ""), "nullable list cannot be used where the interface promises a list")
+
+		nullableListIface := dagql.NewInterface("NullableList", "Allows a nullable list.")
+		nullableListIface.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "names",
+				Type: dagql.Null[dagql.Array[dagql.String]](),
+			},
+		})
+		srv.InstallInterface(nullableListIface)
+		assert.Assert(t, nullableListIface.Satisfies(srv.Root().ObjectType(), ""), "non-null list can be used where the interface allows null")
+	})
+
+	t.Run("method cannot require non-null list when interface allows null", func(t *testing.T) {
+		srv := newExternalDagqlServerForTest(t, Query{})
+		dagql.Fields[Query]{
+			dagql.Func("acceptsNamesOrNull", func(ctx context.Context, self Query, args struct {
+				Names dagql.Optional[dagql.ArrayInput[dagql.String]]
+			}) (string, error) {
+				return "ok", nil
+			}),
+			dagql.Func("acceptsNames", func(ctx context.Context, self Query, args struct {
+				Names dagql.ArrayInput[dagql.String]
+			}) (string, error) {
+				return "ok", nil
+			}),
+		}.Install(srv)
+
+		nullableListArgIface := dagql.NewInterface("NullableListArg", "Allows a nullable list argument.")
+		nullableListArgIface.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "acceptsNames",
+				Type: dagql.String(""),
+				Args: dagql.NewInputSpecs(
+					dagql.InputSpec{Name: "names", Type: dagql.Optional[dagql.ArrayInput[dagql.String]]{}},
+				),
+			},
+		})
+		srv.InstallInterface(nullableListArgIface)
+		assert.Assert(t, !nullableListArgIface.Satisfies(srv.Root().ObjectType(), ""), "method cannot require names when the interface allows names to be null")
+
+		nonNullListArgIface := dagql.NewInterface("NonNullListArg", "Requires a non-null list argument.")
+		nonNullListArgIface.AddField(dagql.InterfaceFieldSpec{
+			FieldSpec: dagql.FieldSpec{
+				Name: "acceptsNamesOrNull",
+				Type: dagql.String(""),
+				Args: dagql.NewInputSpecs(
+					dagql.InputSpec{Name: "names", Type: dagql.ArrayInput[dagql.String]{}},
+				),
+			},
+		})
+		srv.InstallInterface(nonNullListArgIface)
+		assert.Assert(t, nonNullListArgIface.Satisfies(srv.Root().ObjectType(), ""), "method accepting names or null can be used when the interface always passes names")
+	})
+
 	t.Run("auto Node interface", func(t *testing.T) {
 		srv := newExternalDagqlServerForTest(t, Query{})
 		introspection.Install[Query](srv)

--- a/dagql/interfaces.go
+++ b/dagql/interfaces.go
@@ -273,6 +273,14 @@ func argsCompatible(ifaceArgs, objArgs InputSpecs, view call.View, checker Imple
 			return false
 		}
 	}
+	for _, objArg := range objArgs.Inputs(view) {
+		if _, ok := ifaceArgs.Input(objArg.Name, view); ok {
+			continue
+		}
+		if objArg.Default == nil && objArg.Type.Type().NonNull {
+			return false
+		}
+	}
 	return true
 }
 

--- a/dagql/interfaces.go
+++ b/dagql/interfaces.go
@@ -301,6 +301,9 @@ func argTypeCompatible(ifaceArgType, objArgType *ast.Type, checker ImplementsChe
 		if ifaceArgType.Elem == nil || objArgType.Elem == nil {
 			return false
 		}
+		if objArgType.NonNull && !ifaceArgType.NonNull {
+			return false
+		}
 		return argTypeCompatible(ifaceArgType.Elem, objArgType.Elem, checker)
 	}
 	// named types: exact match
@@ -337,6 +340,9 @@ func typeCompatible(ifaceType, objType *ast.Type, checker ImplementsChecker) boo
 	// list types
 	if ifaceType.Elem != nil || objType.Elem != nil {
 		if ifaceType.Elem == nil || objType.Elem == nil {
+			return false
+		}
+		if ifaceType.NonNull && !objType.NonNull {
 			return false
 		}
 		return typeCompatible(ifaceType.Elem, objType.Elem, checker)


### PR DESCRIPTION
While reviewing the interface/codegen PR, I seem to have found five edge cases where the new behavior could produce invalid GraphQL, accept an invalid interface contract, or generate TypeScript clients that do not compile.

This PR keeps the fixes split by failure mode. Each commit contains:
1. a focused regression test that fails without that commit’s fix
2. the corresponding implementation fix
3. a detailed commit message with the broken shape, the fixed shape, and the focused repro command

The elements tested are:
- A module loaded from a `Directory`, for example with `host.directory(...).asModule`, could fail when used through the scale-out path. The generated GraphQL tried to call `asModuleSource` on `node(id:)`, but `node(id:)` only promises a generic `Node`. The query now first narrows that node to `Directory`.

- An object could incorrectly satisfy an interface even when its method required an extra argument that the interface did not declare. For example, `run(target:)` was allowed to implement `run()`, even though callers using the interface have no way to pass `target`.

- A field returning “maybe a list” could incorrectly satisfy an interface field promising “always a list”. The previous check compared the list element type but missed whether the list itself could be null. The same outer-list nullability rule is now also checked for method arguments.

- A TypeScript generated method with an object input named `id` could ask callers for raw `ID` instead of the generated object type. For example, `file(id: File)` could be generated as `file(id: ID)`, causing type errors for callers passing a `File` client object.

- A TypeScript generated method returning a list of interfaces could emit invalid runtime code. The public type should stay `Promise<Syncer[]>`, but internally the generator must construct `_SyncerClient` wrappers for each returned ID. The broken code tried to do `new Syncer(...)`, which cannot compile because `Syncer` is a TypeScript interface.
